### PR TITLE
Set GIT_WORK_TREE for git-checkout-index in export()

### DIFF
--- a/gitosis/repository.py
+++ b/gitosis/repository.py
@@ -118,7 +118,7 @@ def export(git_dir, path):
             '--prefix=%s' % path,
             ],
         close_fds=True,
-        env=dict(GIT_DIR=git_dir),
+        env=dict(GIT_DIR=git_dir, GIT_WORK_TREE=os.getcwd()),
         )
     if returncode != 0:
         raise GitCheckoutIndexError('exit status %d' % returncode)


### PR DESCRIPTION
Fixes git-checkout-index from throwing an error on versions 1.5.3 and above.
This manifested itself upon executing gitosis-init w/ git 1.5.3.4 installed.
However, using git 1.5.2.5, no error was thrown.